### PR TITLE
Allow caching Youtube data and using local file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ typings/
 # gatsby files
 .cache/
 public
+playlist.cache.json
 
 # Mac files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ As such, to support their work, my wife and I have curated some of their videos 
 
 This is also my first tech project with my wife - hence the name dedication. :P
 
+## Environment Variables
+
+### `GATSBY_YOUTUBE_API_KEY` 
+
+Set this to an API KEY with access to Google's Youtube Data API v3
+
+### `GATSBY_USE_LOCAL_DATA`
+
+Set this to true if you want to cache YouTube data and use it instead of calling the API at every build. It will use the API if local file does not exist (i.e. first time.) Default is false, and will call YouTube on build every time (i.e. for production).
+
+After setting up env variables, run:
+
+```bash
+$ npm run develop
+```
+
+
 ## Support our asatizah
 
 - Contribute to Pergas fundraising: https://www.giving.sg/pergas/gracious_package

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,6 +30,7 @@ module.exports = {
       resolve: "gatsby-source-playlist",
       options: {
         apiKey: process.env.GATSBY_YOUTUBE_API_KEY,
+        useLocal: process.env.GATSBY_USE_LOCAL_DATA || false,
       },
     },
     {

--- a/plugins/gatsby-source-playlist/gatsby-node.js
+++ b/plugins/gatsby-source-playlist/gatsby-node.js
@@ -1,46 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const channelMap = require("./channel-map.json");
-const Youtube = require("./youtube").Youtube;
-
-const getAllPlaylistWithVideos = async apiKey => {
-  const yt = new Youtube(apiKey);
-  let allPlaylistWithVideos = [];
-  for (channel of channelMap) {
-    const channelPlaylists = await yt.getChannelPlaylists(channel.channelId);
-    const playlistArr = [];
-    for (playlist of channelPlaylists) {
-      const playlistObj = {
-        id: playlist.id,
-        title: playlist.snippet.title,
-        organisation: playlist.snippet.channelTitle,
-        donationMethod: "<Donation Method>",  // TODO: Pull from some nap.
-        tags: "tags,to,be,implemented",       // TODO: Parse from description?
-        platform: "YouTube",
-        pageUrl: channel.pageUrl,
-        thumbnailUrl: playlist.snippet.thumbnails.medium.url, // Encountered error: thumbnails key (i.e. thumbnails.standard) may not exist.
-      };
-      const playlistVideos = await yt.getPlaylistVideos(playlist.id);
-      const videosArr = playlistVideos.map(video => {
-        return {
-          id: video.snippet.resourceId.videoId,
-          playlistId: video.snippet.playlistId,
-          title: video.snippet.title,
-          asatizah: "<Asatizah name>",        // TODO: Parse from description/title?
-          language: "english",
-          addedOn: video.snippet.publishedAt,
-          videoUrl:
-            "https://www.youtube.com/embed/" +
-            video.snippet.resourceId.videoId,
-        };
-      });
-      playlistObj.videos = videosArr;
-      playlistArr.push(playlistObj);
-    }
-    allPlaylistWithVideos = [...allPlaylistWithVideos, ...playlistArr];
-  }
-  console.log("YouTube API Quota Units used: ", yt.usedQuota);
-  return allPlaylistWithVideos;
-};
+const { getAllPlaylistWithVideos } = require('./utils')
 
 exports.sourceNodes = async (
   { actions, createContentDigest },
@@ -63,7 +21,7 @@ exports.sourceNodes = async (
     return nodeData;
   };
 
-  const playlists = await getAllPlaylistWithVideos(configOptions.apiKey);
+  const playlists = await getAllPlaylistWithVideos(configOptions.apiKey, configOptions.useLocal);
 
   // Creates a new node for each playlist in array.
   playlists.forEach(datum => createNode(processDatum(datum)));

--- a/plugins/gatsby-source-playlist/utils.js
+++ b/plugins/gatsby-source-playlist/utils.js
@@ -1,0 +1,84 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const channelMap = require("./channel-map.json");
+const Youtube = require("./youtube").Youtube;
+const fs = require('fs')
+
+const getAllPlaylistWithVideosFromYoutube = async apiKey => {
+  const yt = new Youtube(apiKey);
+  let allPlaylistWithVideos = [];
+  for (channel of channelMap) {
+    const channelPlaylists = await yt.getChannelPlaylists(channel.channelId);
+    const playlistArr = [];
+    for (playlist of channelPlaylists) {
+      const playlistObj = {
+        id: playlist.id,
+        title: playlist.snippet.title,
+        organisation: playlist.snippet.channelTitle,
+        donationMethod: "<Donation Method>",  // TODO: Pull from some nap.
+        tags: "tags,to,be,implemented",       // TODO: Parse from description?
+        platform: "YouTube",
+        pageUrl: channel.pageUrl,
+        thumbnailUrl: playlist.snippet.thumbnails.medium.url, // Encountered error: thumbnails key (i.e. thumbnails.standard) may not exist.
+      };
+      const playlistVideos = await yt.getPlaylistVideos(playlist.id);
+      const videosArr = playlistVideos.map(video => {
+        return {
+          id: video.snippet.resourceId.videoId,
+          playlistId: video.snippet.playlistId,
+          title: video.snippet.title,
+          asatizah: "<Asatizah name>",        // TODO: Parse from description/title?
+          language: "english",
+          addedOn: video.snippet.publishedAt,
+          videoUrl:
+            "https://www.youtube.com/embed/" +
+            video.snippet.resourceId.videoId,
+        };
+      });
+      playlistObj.videos = videosArr;
+      playlistArr.push(playlistObj);
+    }
+    allPlaylistWithVideos = [...allPlaylistWithVideos, ...playlistArr];
+  }
+  console.log(">>> YouTube API Quota Units used:", yt.usedQuota);
+  return allPlaylistWithVideos;
+};
+
+const getAllPlaylistWithVideos = async (apiKey, useLocal) => {
+  // This path is relative to the root "gatsby-node.js" file calling it.
+  const DATA_PATH = process.env.DATA_PATH || './playlist.cache.json';
+  let playlists = {}
+  if(useLocal && fs.existsSync(DATA_PATH)){
+    console.log(">>> Found local data file. Using this instead of calling YouTube API.")
+    playlists = loadJSON(DATA_PATH);
+  } else {
+    if(useLocal) console.log(">>> Local data not found.")
+    console.log(">>> Retrieving data from YouTube.")
+    playlists = await getAllPlaylistWithVideosFromYoutube(apiKey);
+    if(useLocal){
+      saveJSON(playlists, DATA_PATH);
+      console.log(">>> Youtube data saved locally for future use.");
+    }
+  }
+  
+  return playlists;
+} 
+
+const saveJSON = (data, path) => {
+  try {
+    fs.writeFileSync(path, JSON.stringify(data))
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+const loadJSON = (path) => {
+  try {
+    return JSON.parse(fs.readFileSync(path, 'utf8'))
+  } catch (err) {
+    console.error(err)
+    return false
+  }
+}
+
+
+exports.getAllPlaylistWithVideos = getAllPlaylistWithVideos


### PR DESCRIPTION
- Set `GATSBY_USE_LOCAL_DATA` to save YouTube data to a json file. 
- Future builds will build using the local save file instead of calling YouTube.
- By default this is set to false, meaning YouTube is called on every build (i.e. for production).