### PR TITLE
Bugfix: Update schedule to trigger build at midnight

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Trigger Netlify Build
 on:
   schedule:
-    - cron: '* 0 * * *' # At midnight
+    - cron: '0 0 * * *' # At midnight
 jobs:
   build:
     name: Build on netlify


### PR DESCRIPTION
Currently, it is scheduled to run every min after midnight, which will result in 12 builds. As a result, we can end up using the build limit set by Netlify.