### PR TITLE
Pass datetime format to fix warning message

### DIFF
--- a/src/components/Live/live-sessions.tsx
+++ b/src/components/Live/live-sessions.tsx
@@ -30,7 +30,7 @@ const LiveSessions = (): ReactElement => {
   const isUpcoming = (dateWithoutYear: string, time: string): boolean => {
     const currentYear = moment().get("year");
     const dateTimeWithYear = `${dateWithoutYear} ${currentYear} ${time}`;
-    return moment(dateTimeWithYear).isAfter();
+    return moment(dateTimeWithYear, "D MMM YYYY hh:mm A").isAfter();
   };
 
   const upcomingLiveSessions: LiveSessionModel[] = LiveSessionsData.filter(


### PR DESCRIPTION
To fix the following warning message:
```
[0] _isAMomentObject: true, _isUTC: false, _useUTC: false, _l: undefined, _i: 5 Apr 2020 6:00 AM, _f: undefined, _strict: undefined, _locale: [object Object]
Error
    at Function.createFromInputFallback (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:6492:98)
    at configFromString (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:8557:15)
    at configFromInput (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:8783:13)
    at prepareConfig (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:8766:13)
    at createFromConfig (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:8733:44)
    at createLocalOrUTC (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:8820:16)
    at createLocal (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:8824:16)
    at hooks (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:6184:29)
    at isUpcoming (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:21715:57)
    at LiveSessions.LiveSessionsData.filter.session (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:21718:67)
    at Array.filter (<anonymous>)
    at LiveSessions (/Users/muhammad.muneer/training/react/FatihaTV/public/render-page.js:21718:49)
    at d (/Users/muhammad.muneer/training/react/FatihaTV/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:36:498)
    at $a (/Users/muhammad.muneer/training/react/FatihaTV/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:39:16)
    at a.b.render (/Users/muhammad.muneer/training/react/FatihaTV/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:44:476)
```